### PR TITLE
Updating performance tests for consolidated MueLu factories

### DIFF
--- a/perf_tests/green-1-10km/input_albany_Enthalpy_MueLuKokkos.yaml
+++ b/perf_tests/green-1-10km/input_albany_Enthalpy_MueLuKokkos.yaml
@@ -242,7 +242,7 @@ ANONYMOUS:
                       'aggregation: min agg size': 3
                       'aggregation: phase3 avoid singletons': true
                     MyCoarseMap2: 
-                      factory: CoarseMapFactory_kokkos
+                      factory: CoarseMapFactory
                       Aggregates: UncoupledAggregationFact2
                     myTentativePFact2: 
                       'tentative: calculate qr': true

--- a/perf_tests/green-1-10km/input_albany_Velocity_MueLuKokkos.yaml
+++ b/perf_tests/green-1-10km/input_albany_Velocity_MueLuKokkos.yaml
@@ -291,7 +291,7 @@ ANONYMOUS:
                       'aggregation: min agg size': 3
                       'aggregation: phase3 avoid singletons': true
                     MyCoarseMap2: 
-                      factory: CoarseMapFactory_kokkos
+                      factory: CoarseMapFactory
                       Aggregates: UncoupledAggregationFact2
                     myTentativePFact2: 
                       'tentative: calculate qr': true

--- a/perf_tests/green-3-20km/input_albany_Enthalpy_MueLuKokkos.yaml
+++ b/perf_tests/green-3-20km/input_albany_Enthalpy_MueLuKokkos.yaml
@@ -242,7 +242,7 @@ ANONYMOUS:
                       'aggregation: min agg size': 3
                       'aggregation: phase3 avoid singletons': true
                     MyCoarseMap2: 
-                      factory: CoarseMapFactory_kokkos
+                      factory: CoarseMapFactory
                       Aggregates: UncoupledAggregationFact2
                     myTentativePFact2: 
                       'tentative: calculate qr': true

--- a/perf_tests/green-3-20km/input_albany_Velocity_MueLuKokkos.yaml
+++ b/perf_tests/green-3-20km/input_albany_Velocity_MueLuKokkos.yaml
@@ -291,7 +291,7 @@ ANONYMOUS:
                       'aggregation: min agg size': 3
                       'aggregation: phase3 avoid singletons': true
                     MyCoarseMap2: 
-                      factory: CoarseMapFactory_kokkos
+                      factory: CoarseMapFactory
                       Aggregates: UncoupledAggregationFact2
                     myTentativePFact2: 
                       'tentative: calculate qr': true

--- a/perf_tests/humboldt-3-20km/input_albany_Velocity_MueLuKokkos.yaml
+++ b/perf_tests/humboldt-3-20km/input_albany_Velocity_MueLuKokkos.yaml
@@ -293,7 +293,7 @@ ANONYMOUS:
                       'aggregation: min agg size': 3
                       'aggregation: phase3 avoid singletons': true
                     MyCoarseMap2: 
-                      factory: CoarseMapFactory_kokkos
+                      factory: CoarseMapFactory
                       Aggregates: UncoupledAggregationFact2
                     myTentativePFact2: 
                       'tentative: calculate qr': true


### PR DESCRIPTION
MueLu is currently merging *_kokkos factories with their classical counterparts (https://github.com/trilinos/Trilinos/issues/11658) and our GPU performance tests will need to be updated accordingly. This PR replaces instances of CoarseMapFactory_kokkos with CoarseMapFactory. I'll keep an eye on this issue and update performance tests as factories are updated.