### PR TITLE
Don't save solution field when populating meshes

### DIFF
--- a/perf_tests/green-1-10km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/green-1-10km/input_albany_PopulateMesh.yaml
@@ -26,6 +26,7 @@ ANONYMOUS:
       basalside:
         Number Of Time Derivatives: 0
         Method: Ioss
+        Save Solution Field: false
         Exodus Input File Name: mesh-decomp/gis_2d.exo
         Exodus Output File Name: mesh-pop/gis_basal_populated.exo
         Required Fields Info: 
@@ -108,6 +109,7 @@ ANONYMOUS:
         Number Of Time Derivatives: 0
         Method: SideSetSTK
         Exodus Output File Name: mesh-pop/gis_upper_populated.exo
+        Save Solution Field: false
         Required Fields Info: 
           Number Of Fields: 2
           Field 0:

--- a/perf_tests/green-3-20km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/green-3-20km/input_albany_PopulateMesh.yaml
@@ -26,6 +26,7 @@ ANONYMOUS:
       basalside:
         Number Of Time Derivatives: 0
         Method: Ioss
+        Save Solution Field: false
         Exodus Input File Name: mesh-decomp/gis_1k_2d.exo
         Exodus Output File Name: mesh-pop/gis_basal_populated.exo
         Required Fields Info: 
@@ -107,6 +108,7 @@ ANONYMOUS:
       upperside:
         Number Of Time Derivatives: 0
         Method: SideSetSTK
+        Save Solution Field: false
         Exodus Output File Name: mesh-pop/gis_upper_populated.exo
         Required Fields Info: 
           Number Of Fields: 2

--- a/perf_tests/humboldt-1-10km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/humboldt-1-10km/input_albany_PopulateMesh.yaml
@@ -28,6 +28,7 @@ ANONYMOUS:
         Workset Size: -1
         Number Of Time Derivatives: 0
         Method: Ioss
+        Save Solution Field: false
         Exodus Input File Name: mesh-decomp/humboldt_2d.exo
         Exodus Output File Name: mesh-pop/humboldt_basal_populated.exo
         Required Fields Info:
@@ -90,6 +91,7 @@ ANONYMOUS:
         Number Of Time Derivatives: 0
         Method: SideSetSTK
         Exodus Output File Name: mesh-pop/humboldt_upper_populated.exo
+        Save Solution Field: false
         Required Fields Info:
           Number Of Fields: 2
           Field 0:

--- a/perf_tests/humboldt-3-20km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/humboldt-3-20km/input_albany_PopulateMesh.yaml
@@ -28,6 +28,7 @@ ANONYMOUS:
         Workset Size: -1
         Number Of Time Derivatives: 0
         Method: Ioss
+        Save Solution Field: false
         Exodus Input File Name: mesh-decomp/humboldt_2d.exo
         Exodus Output File Name: mesh-pop/humboldt_basal_populated.exo
         Required Fields Info:
@@ -89,6 +90,7 @@ ANONYMOUS:
         Number Of Time Derivatives: 0
         Method: SideSetSTK
         Exodus Output File Name: mesh-pop/humboldt_upper_populated.exo
+        Save Solution Field: false
         Required Fields Info:
           Number Of Fields: 2
           Field 0:

--- a/perf_tests/thwaites-1-10km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/thwaites-1-10km/input_albany_PopulateMesh.yaml
@@ -28,6 +28,7 @@ ANONYMOUS:
         Workset Size: -1
         Number Of Time Derivatives: 0
         Method: Ioss
+        Save Solution Field: false
         Exodus Input File Name: mesh-decomp/thwaites_2d.exo
         Exodus Output File Name: mesh-pop/thwaites_basal_populated.exo
         Required Fields Info:
@@ -89,6 +90,7 @@ ANONYMOUS:
       upperside:
         Number Of Time Derivatives: 0
         Method: SideSetSTK
+        Save Solution Field: false
         Exodus Output File Name: mesh-pop/thwaites_upper_populated.exo
         Required Fields Info:
           Number Of Fields: 2


### PR DESCRIPTION
Recent changes in Albany (switch to STK simple fields across the board) force us to NOT have the solution field in an input mesh (unless performing a true restart). So populate mesh problems should refrain from saving solution.