### PR TITLE
Change keyword to request STK extruded discretization

### DIFF
--- a/perf_tests/green-1-10km/input_albany_Enthalpy_FiniteElementAssembly_Memoization.yaml
+++ b/perf_tests/green-1-10km/input_albany_Enthalpy_FiniteElementAssembly_Memoization.yaml
@@ -78,7 +78,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-1-10km/input_albany_Enthalpy_MueLu.yaml
+++ b/perf_tests/green-1-10km/input_albany_Enthalpy_MueLu.yaml
@@ -78,7 +78,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-1-10km/input_albany_Enthalpy_MueLuKokkos.yaml
+++ b/perf_tests/green-1-10km/input_albany_Enthalpy_MueLuKokkos.yaml
@@ -78,7 +78,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-1-10km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/green-1-10km/input_albany_PopulateMesh.yaml
@@ -10,7 +10,7 @@ ANONYMOUS:
 # Discretization Description
   Discretization: 
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-1-10km/input_albany_Velocity_MueLu.yaml
+++ b/perf_tests/green-1-10km/input_albany_Velocity_MueLu.yaml
@@ -90,7 +90,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-1-10km/input_albany_Velocity_MueLuKokkos.yaml
+++ b/perf_tests/green-1-10km/input_albany_Velocity_MueLuKokkos.yaml
@@ -90,7 +90,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-1-10km/input_albany_Velocity_MueLu_Tune.yaml
+++ b/perf_tests/green-1-10km/input_albany_Velocity_MueLu_Tune.yaml
@@ -90,7 +90,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_BasalFrictionInit_Memoization.yaml
+++ b/perf_tests/green-3-20km/input_albany_BasalFrictionInit_Memoization.yaml
@@ -103,7 +103,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_BasalFrictionInit_MemoizationForParams.yaml
+++ b/perf_tests/green-3-20km/input_albany_BasalFrictionInit_MemoizationForParams.yaml
@@ -103,7 +103,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_BasalFrictionInit_SingleWorkset.yaml
+++ b/perf_tests/green-3-20km/input_albany_BasalFrictionInit_SingleWorkset.yaml
@@ -103,7 +103,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_Enthalpy_FiniteElementAssembly_Memoization.yaml
+++ b/perf_tests/green-3-20km/input_albany_Enthalpy_FiniteElementAssembly_Memoization.yaml
@@ -78,7 +78,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_Enthalpy_FiniteElementAssembly_SingleWorkset.yaml
+++ b/perf_tests/green-3-20km/input_albany_Enthalpy_FiniteElementAssembly_SingleWorkset.yaml
@@ -78,7 +78,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_Enthalpy_MueLuKokkos.yaml
+++ b/perf_tests/green-3-20km/input_albany_Enthalpy_MueLuKokkos.yaml
@@ -78,7 +78,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/green-3-20km/input_albany_PopulateMesh.yaml
@@ -10,7 +10,7 @@ ANONYMOUS:
 # Discretization Description
   Discretization: 
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_Velocity_FiniteElementAssembly_Memoization.yaml
+++ b/perf_tests/green-3-20km/input_albany_Velocity_FiniteElementAssembly_Memoization.yaml
@@ -90,7 +90,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_Velocity_FiniteElementAssembly_SingleWorkset.yaml
+++ b/perf_tests/green-3-20km/input_albany_Velocity_FiniteElementAssembly_SingleWorkset.yaml
@@ -90,7 +90,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_Velocity_MueLu.yaml
+++ b/perf_tests/green-3-20km/input_albany_Velocity_MueLu.yaml
@@ -90,7 +90,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/green-3-20km/input_albany_Velocity_MueLuKokkos.yaml
+++ b/perf_tests/green-3-20km/input_albany_Velocity_MueLuKokkos.yaml
@@ -90,7 +90,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-1-10km/input_albany_Coupled_FROSch.yaml
+++ b/perf_tests/humboldt-1-10km/input_albany_Coupled_FROSch.yaml
@@ -127,7 +127,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-1-10km/input_albany_Coupled_FiniteElementAssembly.yaml
+++ b/perf_tests/humboldt-1-10km/input_albany_Coupled_FiniteElementAssembly.yaml
@@ -112,7 +112,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-1-10km/input_albany_Coupled_Ifpack2.yaml
+++ b/perf_tests/humboldt-1-10km/input_albany_Coupled_Ifpack2.yaml
@@ -127,7 +127,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-1-10km/input_albany_Enthalpy_MueLu.yaml
+++ b/perf_tests/humboldt-1-10km/input_albany_Enthalpy_MueLu.yaml
@@ -78,7 +78,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-1-10km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/humboldt-1-10km/input_albany_PopulateMesh.yaml
@@ -11,7 +11,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-1-10km/input_albany_Velocity_MueLu.yaml
+++ b/perf_tests/humboldt-1-10km/input_albany_Velocity_MueLu.yaml
@@ -102,7 +102,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-3-20km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/humboldt-3-20km/input_albany_PopulateMesh.yaml
@@ -11,7 +11,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-3-20km/input_albany_Velocity_MueLu.yaml
+++ b/perf_tests/humboldt-3-20km/input_albany_Velocity_MueLu.yaml
@@ -90,7 +90,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-3-20km/input_albany_Velocity_MueLuKokkos.yaml
+++ b/perf_tests/humboldt-3-20km/input_albany_Velocity_MueLuKokkos.yaml
@@ -104,7 +104,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/humboldt-3-20km/input_albany_Velocity_MueLu_Tune.yaml
+++ b/perf_tests/humboldt-3-20km/input_albany_Velocity_MueLu_Tune.yaml
@@ -90,7 +90,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/thwaites-1-10km/input_albany_Coupled_FROSch.yaml
+++ b/perf_tests/thwaites-1-10km/input_albany_Coupled_FROSch.yaml
@@ -127,7 +127,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/thwaites-1-10km/input_albany_Coupled_Ifpack2.yaml
+++ b/perf_tests/thwaites-1-10km/input_albany_Coupled_Ifpack2.yaml
@@ -127,7 +127,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/thwaites-1-10km/input_albany_Enthalpy_MueLu.yaml
+++ b/perf_tests/thwaites-1-10km/input_albany_Enthalpy_MueLu.yaml
@@ -78,7 +78,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/thwaites-1-10km/input_albany_PopulateMesh.yaml
+++ b/perf_tests/thwaites-1-10km/input_albany_PopulateMesh.yaml
@@ -11,7 +11,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true

--- a/perf_tests/thwaites-1-10km/input_albany_Velocity_MueLu.yaml
+++ b/perf_tests/thwaites-1-10km/input_albany_Velocity_MueLu.yaml
@@ -102,7 +102,7 @@ ANONYMOUS:
   Discretization: 
     Workset Size: -1
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     NumLayers: 10
     Columnwise Ordering: true
     Use Glimmer Spacing: true


### PR DESCRIPTION
After merging sandialabs/albany#1076, the keyword needed to request the good old STK extruded discretization has changed. This PR fixes the yaml files for perf tests accordingly.