### PR TITLE
Fix failing optimization cases on blake

### DIFF
--- a/perf_tests/green-3-20km/input_albany_BasalFrictionInit_Memoization.yaml
+++ b/perf_tests/green-3-20km/input_albany_BasalFrictionInit_Memoization.yaml
@@ -55,6 +55,7 @@ ANONYMOUS:
         Type: Lateral
         Cubature Degree: 4
         Side Set Name: extruded_boundary_side_set_1
+    Dirichlet BCs: {}
     LandIce Field Norm:
       sliding_velocity_basalside:
         Regularization Type: Given Value

--- a/perf_tests/green-3-20km/input_albany_BasalFrictionInit_MemoizationForParams.yaml
+++ b/perf_tests/green-3-20km/input_albany_BasalFrictionInit_MemoizationForParams.yaml
@@ -55,6 +55,7 @@ ANONYMOUS:
         Type: Lateral
         Cubature Degree: 4
         Side Set Name: extruded_boundary_side_set_1
+    Dirichlet BCs: {}
     LandIce Field Norm:
       sliding_velocity_basalside:
         Regularization Type: Given Value

--- a/perf_tests/green-3-20km/input_albany_BasalFrictionInit_SingleWorkset.yaml
+++ b/perf_tests/green-3-20km/input_albany_BasalFrictionInit_SingleWorkset.yaml
@@ -55,6 +55,7 @@ ANONYMOUS:
         Type: Lateral
         Cubature Degree: 4
         Side Set Name: extruded_boundary_side_set_1
+    Dirichlet BCs: {}
     LandIce Field Norm:
       sliding_velocity_basalside:
         Regularization Type: Given Value


### PR DESCRIPTION
This fixes the failing optimization cases on blake. see https://github.com/sandialabs/Albany/issues/911
 
@mperego found some wrong logic in Albany that tries to access a bc vector that has not been defined if you leave Dirichlet BCs out. This happens in the adjoint computation. He's working on a fix.