### PR TITLE
Update Tacho parameters for humboldt-1-10km

### DIFF
--- a/perf_tests/humboldt-1-10km/input_cop_fro_tch.yaml
+++ b/perf_tests/humboldt-1-10km/input_cop_fro_tch.yaml
@@ -351,7 +351,7 @@ ANONYMOUS:
                           'method' : lu
                           'variant': 0
                           'dofs-per-node': 4
-                          'perturb-pivot': true
+                          'shift-diag': true
                   IPOUHarmonicCoarseOperator:
                     'Reuse: Coarse Basis': true                            # Reuse of the coarse basis functions
                     'Reuse: Coarse Matrix': false                           # Reuse of the coarse matrix
@@ -377,7 +377,7 @@ ANONYMOUS:
                           'method' : lu
                           'variant': 0
                           'dofs-per-node': 4
-                          'perturb-pivot': true
+                          'shift-diag': true
                     Distribution:                                           # Parallel distribution of the coarse problem
                       Type: linear                                          # Specifies the parallel distribution strategy. For now, we use "linear"
                       NumProcs: 1                                           # Number of ranks used for the coarse problem
@@ -390,5 +390,5 @@ ANONYMOUS:
                           'method' : lu
                           'variant': 0
                           'dofs-per-node': 4
-                          'perturb-pivot': true
+                          'shift-diag': true
 ...

--- a/perf_tests/humboldt-1-10km/input_cop_if2_tch.yaml
+++ b/perf_tests/humboldt-1-10km/input_cop_if2_tch.yaml
@@ -340,5 +340,5 @@ ANONYMOUS:
                         'method' : lu
                         'variant': 0
                         'dofs-per-node': 4
-                        'perturb-pivot': true
+                        'shift-diag': true
 ...


### PR DESCRIPTION

This updates the Tacho parameters for humboldt-1-10km, following the Trilinos PR [14931](https://github.com/trilinos/Trilinos/pull/14931), and also [14958](https://github.com/trilinos/Trilinos/pull/14958).